### PR TITLE
Fix minor webpack and package.json issues

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -20,7 +20,9 @@ You need to start both for full testing:
 $ npm start
 
 # start the json-server:
-$ ./node_modules/.bin/json-server --watch dummy.json
+$ npm json-server
+# which actually calls:
+# $ ./node_modules/.bin/json-server --watch dummy.json
 ```
 
 The dev version of the frontend is then available at http://localhost:8080.

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "webpack --env.production",
-    "start": "webpack-dev-server --open"
+    "start": "webpack-dev-server --open",
+    "json-server": "json-server --watch dummy.json"
   },
   "keywords": [],
   "author": "",

--- a/web/package.json
+++ b/web/package.json
@@ -23,6 +23,7 @@
     "html-loader": "^0.5.5",
     "html-webpack-inline-source-plugin": "0.0.9",
     "html-webpack-plugin": "^2.30.1",
+    "uglifyjs-webpack-plugin": "^0.4.6",
     "json-server": "^0.12.1",
     "material-ui": "^1.0.0-beta.31",
     "material-ui-icons": "^1.0.0-beta.17",

--- a/web/webpack.config.js
+++ b/web/webpack.config.js
@@ -2,7 +2,7 @@ const webpack = require('webpack');
 
 const path = require("path");
 const HtmlWebPackPlugin = require("html-webpack-plugin");
-const UglifyJsPlugin = require('uglifyjs-webpack-plugin')
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 const HtmlWebpackInlineSourcePlugin = require('html-webpack-inline-source-plugin');
 
 


### PR DESCRIPTION
Some minor issues in the configuration files:
- uglifyjs-webpack-plugin is missing from package.json
- missing ;
This does not break anything, it just lites up in IDEA.

Then, instead or running the json-server manually, it can be started via npm run. This is not really related to the minor fixes.